### PR TITLE
YaKaPatcher: Add extra events by patching IDA module

### DIFF
--- a/YaCo/YaCo.py
+++ b/YaCo/YaCo.py
@@ -35,6 +35,7 @@ else:
 import hooks
 import repository
 import yatools
+from patch.YaCoPatch import patch_ida_module
 
 logging.basicConfig()
 logger = None
@@ -285,6 +286,16 @@ class YaCo:
         Create and initialize Python subsystem
         """
         idaapi.msg("YaCo %s\n" % YACO_VERSION)
+
+        try:
+            patch_ida_module()
+        except Exception, e:
+            cont = idc.AskYN(
+                -1,
+                "An Error occurred while patching IDA module:\n%s\nDo you want to ignore this error and continue?\n"
+                % e.message)
+            if cont != 1:
+                raise
 
         self.hash_provider = ya.YaToolsHashProvider()
         self.repo_manager = repository.YaToolRepoManager(idc.GetIdbPath())

--- a/YaCo/patch/YaCoPatch.py
+++ b/YaCo/patch/YaCoPatch.py
@@ -1,0 +1,308 @@
+#   Copyright (C) 2017 YaKaPatcher
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import idaapi
+import logging
+import ctypes
+import struct
+import binascii
+from ctypes.util import find_library
+
+logging.basicConfig()
+logger = logging.getLogger("YaCoPatch")
+logger.setLevel(logging.DEBUG)
+
+def linux_ida_module_baseaddr(use_64, init_kernel_baseoffset):
+    if not use_64:
+        # get handle on libida.so
+        libida_so = ctypes.cdll.LoadLibrary("libida.so")
+    else:
+        # get handle on libida64.so
+        libida_so = ctypes.cdll.LoadLibrary("libida64.so")
+    # get init_kernel address in libida.so
+    f_init_kernel = libida_so.init_kernel
+    p_init_kernel = ctypes.cast(f_init_kernel, ctypes.c_void_p)
+    libida_baseaddr = p_init_kernel.value - init_kernel_baseoffset
+
+    # get libc
+    libc_name = find_library("c")
+    libc_so = ctypes.cdll.LoadLibrary(libc_name)
+
+    # unprotect page
+    libc_so.mprotect(libida_baseaddr, 0x2FA000, 0x7)
+
+    return libida_baseaddr
+
+def windows_ida_module_baseaddr(use_64):
+    if use_64:
+        libida_baseaddr = ctypes.windll.kernel32.GetModuleHandleA("ida64.wll")  # @UndefinedVariable
+    else:
+        libida_baseaddr = ctypes.windll.kernel32.GetModuleHandleA("ida.wll")  # @UndefinedVariable
+    if libida_baseaddr == 0:
+        raise Exception("Unable to get ida(64).wll module handle.")
+
+    # unprotect lib
+    old = ctypes.c_uint32()
+    if ctypes.windll.kernel32.VirtualProtect(libida_baseaddr, 0x198000, 0x40, ctypes.byref(old)) != 1:  # PAGE_EXECUTE_READWRITE @UndefinedVariable
+        logger.debug("Unable to unprotect module.")
+        raise Exception("Unable to unprotect module.")
+
+    return libida_baseaddr
+
+def patch_ida_module():
+    logger.debug("Patching IDA module...")
+
+    # check 32/64 bit
+    if idaapi.BADADDR == 0xffffffff:
+        use_64 = False
+    else:
+        use_64 = True
+
+    if sys.platform == "linux2":
+        build_hook_fn = build_hook_linux
+    elif sys.platform == "win32":
+        build_hook_fn = build_hook_windows
+        libida_baseaddr = windows_ida_module_baseaddr(use_64)
+    else:
+        raise Exception("Unhandled platform")
+
+    events_offset = []
+
+    if idaapi.IDA_SDK_VERSION == 695:
+        """
+        IDA 695
+        """
+        import YaCoPatch_695
+        if sys.platform == "linux2":
+            # linux
+            if not use_64:
+                init_kernel_baseoffset = 0x00030400
+            else:
+                init_kernel_baseoffset = 0x00031720
+            libida_baseaddr = linux_ida_module_baseaddr(use_64, init_kernel_baseoffset)
+
+            if not use_64:
+                # linux 32
+                hooks_offsets = YaCoPatch_695.ida_695_linux_32_hooks_offsets(libida_baseaddr)
+
+            else:
+                # linux 64
+                hooks_offsets = YaCoPatch_695.ida_695_linux_64_hooks_offsets(libida_baseaddr)
+
+        elif sys.platform == "win32":
+
+            # windows
+            if not use_64:
+                # windows 32
+                hooks_offsets = YaCoPatch_695.ida_695_windows_32_hooks_offsets(libida_baseaddr)
+
+            else:
+                # windows 64
+                hooks_offsets = YaCoPatch_695.ida_695_windows_64_hooks_offsets(libida_baseaddr)
+
+    elif idaapi.IDA_SDK_VERSION == 680:
+        """
+        IDA 680
+        """
+        import YaCoPatch_680
+        if sys.platform == "win32":
+            # windows
+            if not use_64:
+                hooks_offsets = YaCoPatch_680.ida_680_windows_32_hooks_offsets(libida_baseaddr)
+                events_offset = [0x6e58f, 0x6e63e]
+
+            else:
+                hooks_offsets = YaCoPatch_680.ida_680_windows_64_hooks_offsets(libida_baseaddr)
+                events_offset = [0x76cfa, 0x76d33]
+        else:
+            raise Exception("Unhandled platform")
+
+    else:
+        logger.error("Unhandled IDA version, use IDA 6.8 or IDA 6.95")
+        return
+
+    for event_offset in events_offset:
+        # PATCHING AREA (EXTRA) COMMENT EVENT (update and delete) (ie pre/post comments)
+        b = (ctypes.c_char * 1).from_address(libida_baseaddr + event_offset)
+        if b[0] == '\x3b':
+            b[0] = '\x01'
+            logger.debug("IDA DLL area comment patched")
+        elif b[0] == '\x01':
+            logger.debug("IDA DLL already patched !")
+            return
+        else:
+            logger.error("IDA DLL mismatch !")
+            raise Exception("IDA DLL mismatch !")
+
+    # PATCHING REGVAR EVENT
+    try:
+        build_hook_fn(hooks_offsets['regvar_hook_addr'], hooks_offsets['regvar_hook_return_addr'], hooks_offsets['regvar_handler_bytes'])
+        logger.debug("IDA Module regvar patched")
+    except KeyError:
+        logger.debug("Unable to patch IDA Module regvar")
+
+    # PATCHING REGVAR RENAME EVENT
+    try:
+        build_hook_fn(hooks_offsets['rename_hook_addr'], hooks_offsets['rename_hook_return_addr'], hooks_offsets['rename_handler_bytes'])
+        logger.debug("IDA Module regvar rename patched")
+    except KeyError:
+        logger.debug("Unable to patch IDA Module regvar rename")
+
+    # PATCHING TOGGLE SIGN EVENT
+    try:
+        build_hook_fn(hooks_offsets['toogle_hook_addr'], hooks_offsets['toogle_hook_return_addr'], hooks_offsets['toggle_sign_handler_bytes'])
+        logger.debug("IDA Module toggle sign patched")
+    except KeyError:
+        logger.debug("Unable to patch IDA Module toggle sign")
+
+    # PATCHING MARK COMMENT EVENT AND DELETE MARK
+    try:
+        build_hook_fn(hooks_offsets['mark_comment_hook_addr'], hooks_offsets['mark_comment_hook_return_addr'], hooks_offsets['mark_comment_handler_bytes'])
+        logger.debug("IDA Module mark comments patched")
+    except KeyError:
+        logger.debug("Unable to patch IDA Module mark comments")
+
+    # PATCHING AREA COMMENT EVENT
+    try:
+        build_hook_fn(hooks_offsets['add_hidden_area_hook_addr'], hooks_offsets['add_hidden_area_hook_return_addr'], hooks_offsets['add_hidden_area_handler_bytes'])
+        logger.debug("IDA Module area comments patched")
+    except KeyError:
+        logger.debug("Unable to patch IDA Module area comments")
+
+    # PATCHING FUNCTION FLAGS EVENT
+    try:
+        build_hook_fn(hooks_offsets['function_flags_hook_addr'], hooks_offsets['function_flags_hook_return_addr'], hooks_offsets['function_flags_handler_bytes'])
+        logger.debug("IDA Module function flags patched")
+    except KeyError:
+        logger.debug("Unable to patch IDA Module function flags")
+
+    # PATCHING ENUM WIDTH EVENT
+    try:
+        build_hook_fn(hooks_offsets['enum_width_hook_addr'], hooks_offsets['enum_width_hook_return_addr'], hooks_offsets['enum_width_handler_bytes'])
+        logger.debug("IDA Module enum width patched")
+    except KeyError:
+        logger.debug("Unable to patch IDA Module enum width")
+
+    logger.debug("IDA Module patched")
+
+def pack_address(address):
+    return struct.pack("I", address)
+
+def build_trampoline(handler_address):
+    """
+    push @handler
+    ret
+    """
+    # push handler address
+    trampoline = '\x68'  # push
+    trampoline += pack_address(handler_address)
+
+    # ret
+    trampoline += '\xc3'
+
+    return trampoline
+
+def build_hook_windows(hook_addr, hook_return_addr, handler_bytes):
+    # RETURN
+    handler_return_bytes = build_trampoline(hook_return_addr)
+    original_code_size = hook_return_addr - hook_addr
+    handler_size = len(handler_bytes) + original_code_size + len(handler_return_bytes)
+
+    # -- allocate handler
+    handler_addr = ctypes.windll.kernel32.VirtualAlloc(
+        None, handler_size, 0x1000, 0x40)  # MEM_COMMIT / EXECUTE_READ_WRITE  # @UndefinedVariable
+    if handler_addr == None:
+        raise Exception("Unable to VirtualAllocEx to build hook !")
+
+    # -- write handler
+    b = (ctypes.c_char * handler_size).from_address(handler_addr)
+    i = 0
+    for byte in handler_bytes:
+        b[i] = byte
+        i += 1
+
+    # -- write original code
+    original_code_size = hook_return_addr - hook_addr
+    original_code_bytes = (ctypes.c_char * original_code_size).from_address(hook_addr)
+
+    for j in xrange(0, original_code_size):
+        b[i] = original_code_bytes[j]
+        i += 1
+
+    # -- write return
+    for byte in handler_return_bytes:
+        b[i] = byte
+        i += 1
+
+    # write hook
+    # HOOK
+    hook_bytes = build_trampoline(handler_addr)
+
+    old = ctypes.c_uint32()
+    if ctypes.windll.kernel32.VirtualProtect(hook_addr, len(hook_bytes), 0x40, ctypes.byref(old)) != 1:  # @UndefinedVariable
+        raise Exception("Unable to unprotect module.")
+    b = (ctypes.c_char * len(hook_bytes)).from_address(hook_addr)
+    i = 0
+    for byte in hook_bytes:
+        b[i] = byte
+        i += 1
+
+def build_hook_linux(hook_addr, hook_return_addr, handler_bytes):
+    # RETURN
+    handler_return_bytes = build_trampoline(hook_return_addr)
+    original_code_size = hook_return_addr - hook_addr
+    handler_size = len(handler_bytes) + original_code_size + len(handler_return_bytes)
+
+    # -- allocate handler
+    # get libc
+    libc_name = find_library("c")
+    libc_so = ctypes.cdll.LoadLibrary(libc_name)
+    handler_addr = libc_so.valloc(handler_size)  # @UndefinedVariable
+    if handler_addr == 0:
+        raise Exception("Unable to malloc to build hook !")
+    if libc_so.mprotect(handler_addr, handler_size, 0x7) != 0:  # PROT_READ / PROT_WRITE / PROT_EXEC
+        raise Exception("Unable to unprotect buffer !")
+
+    # -- write handler
+    b = (ctypes.c_char * handler_size).from_address(handler_addr)
+    i = 0
+    for byte in handler_bytes:
+        b[i] = byte
+        i += 1
+
+    # -- write original code
+    original_code_size = hook_return_addr - hook_addr
+    original_code_bytes = (ctypes.c_char * original_code_size).from_address(hook_addr)
+
+    for j in xrange(0, original_code_size):
+        b[i] = original_code_bytes[j]
+        i += 1
+
+    # -- write return
+    for byte in handler_return_bytes:
+        b[i] = byte
+        i += 1
+
+    # write hook
+    # HOOK
+    hook_bytes = build_trampoline(handler_addr)
+
+    b = (ctypes.c_char * len(hook_bytes)).from_address(hook_addr)
+    i = 0
+    for byte in hook_bytes:
+        b[i] = byte
+        i += 1
+

--- a/YaCo/patch/YaCoPatch_680.py
+++ b/YaCo/patch/YaCoPatch_680.py
@@ -1,0 +1,300 @@
+#   Copyright (C) 2017 YaKaPatcher
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import YaCoPatch
+
+#
+# IDA 680
+#
+# windows
+def ida_680_windows_32_hooks_offsets(libida_baseaddr):
+    hooks_offsets = {}
+
+    send_event_offset = 0x1265d0
+    hooks_offsets['send_event_addr'] = libida_baseaddr + send_event_offset
+
+    regvar_hook_offset = 0x6c332
+    hooks_offsets['regvar_hook_addr']= libida_baseaddr + regvar_hook_offset
+    hooks_offsets['regvar_hook_return_addr'] = hooks_offsets['regvar_hook_addr']+ 0x8
+
+    hooks_offsets['regvar_handler_bytes'] = build_regvar_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    rename_regvar_hook_offset = 0x6c1ab
+    hooks_offsets['rename_hook_addr'] = libida_baseaddr + rename_regvar_hook_offset
+    hooks_offsets['rename_hook_return_addr'] = hooks_offsets['rename_hook_addr']+ 0x8
+
+    hooks_offsets['rename_handler_bytes'] = build_rename_regvar_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    toggle_hook_offset = 0xf11c0
+    hooks_offsets['toogle_hook_addr'] = libida_baseaddr + toggle_hook_offset
+    hooks_offsets['toogle_hook_return_addr'] = hooks_offsets['toogle_hook_addr'] + 0x6
+
+    hooks_offsets['toggle_sign_handler_bytes'] = build_toggle_sign_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    mark_comment_hook_offset = 0x98d47
+    hooks_offsets['mark_comment_hook_addr'] = libida_baseaddr + mark_comment_hook_offset
+    hooks_offsets['mark_comment_hook_return_addr'] = hooks_offsets['mark_comment_hook_addr'] + 0x8
+
+    hooks_offsets['mark_comment_handler_bytes'] = build_mark_comment_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    add_hidden_area_hook_offset = 0xe8077
+    hooks_offsets['add_hidden_area_hook_addr'] = libida_baseaddr + add_hidden_area_hook_offset
+    hooks_offsets['add_hidden_area_hook_return_addr'] = hooks_offsets['add_hidden_area_hook_addr'] + 0x7
+
+    hooks_offsets['add_hidden_area_handler_bytes'] = build_add_hidden_area_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    enum_width_hook_offset = 0xf7a2a
+    hooks_offsets['enum_width_hook_addr'] = libida_baseaddr + enum_width_hook_offset
+    hooks_offsets['enum_width_hook_return_addr'] = hooks_offsets['enum_width_hook_addr'] + 0x8
+
+    hooks_offsets['enum_width_handler_bytes'] = build_enum_width_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    return hooks_offsets
+
+def ida_680_windows_64_hooks_offsets(libida_baseaddr):
+    hooks_offsets = {}
+
+    send_event_offset = 0x13C720
+    hooks_offsets['send_event_addr'] = libida_baseaddr + send_event_offset
+
+    regvar_hook_offset = 0x74132
+    hooks_offsets['regvar_hook_addr']= libida_baseaddr + regvar_hook_offset
+    hooks_offsets['regvar_hook_return_addr'] = hooks_offsets['regvar_hook_addr']+ 0x8
+
+    hooks_offsets['regvar_handler_bytes'] = build_regvar_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    rename_regvar_hook_offset = 0x73F8B
+    hooks_offsets['rename_hook_addr'] = libida_baseaddr + rename_regvar_hook_offset
+    hooks_offsets['rename_hook_return_addr'] = hooks_offsets['rename_hook_addr']+ 0x9
+
+    hooks_offsets['rename_handler_bytes'] = build_rename_regvar_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    toggle_hook_offset = 0x101655
+    hooks_offsets['toogle_hook_addr'] = libida_baseaddr + toggle_hook_offset
+    hooks_offsets['toogle_hook_return_addr'] = hooks_offsets['toogle_hook_addr'] + 0x6
+
+    hooks_offsets['toggle_sign_handler_bytes'] = build_toggle_sign_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    mark_comment_hook_offset = 0xA32C0
+    hooks_offsets['mark_comment_hook_addr'] = libida_baseaddr + mark_comment_hook_offset
+    hooks_offsets['mark_comment_hook_return_addr'] = hooks_offsets['mark_comment_hook_addr'] + 0xb
+
+    hooks_offsets['mark_comment_handler_bytes'] = build_mark_comment_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    add_hidden_area_hook_offset = 0xF706B
+    hooks_offsets['add_hidden_area_hook_addr'] = libida_baseaddr + add_hidden_area_hook_offset
+    hooks_offsets['add_hidden_area_hook_return_addr'] = hooks_offsets['add_hidden_area_hook_addr'] + 0x7
+
+    hooks_offsets['add_hidden_area_handler_bytes'] = build_add_hidden_area_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    enum_width_hook_offset = 0x10988A
+    hooks_offsets['enum_width_hook_addr'] = libida_baseaddr + enum_width_hook_offset
+    hooks_offsets['enum_width_hook_return_addr'] = hooks_offsets['enum_width_hook_addr'] + 0x7
+
+    hooks_offsets['enum_width_handler_bytes'] = build_enum_width_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    return hooks_offsets
+
+def build_regvar_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x44\x24\x48'  # mov 0x48(%esp), %eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x0c'  # add $0xC, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_regvar_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x68\xd0\x07\x00\x00'  # push $0x7d0
+    handler_send_event_bytes += '\x8b\x44\x24\x60'  # mov 0x60(%esp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x44\x24\x60'  # mov 0x60(%esp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x14'  # add $0x14, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_rename_regvar_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x03'  # mov    (%ebx),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x0c'  # add $0xC, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_rename_regvar_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x68\xd0\x07\x00\x00'  # push $0x7d0
+    handler_send_event_bytes += '\x8b\x43\x04'  # mov 0x4(%ebx),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x03'  # mov (%ebx),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x14'  # add $0x14, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_toggle_sign_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x0c'  # add $0xc, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_toggle_sign_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x68\xd0\x07\x00\x00'  # push $0x7d0
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x57'  # push %edi
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x14'  # add $0x14, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_mark_comment_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x44\x24\x40'  # mov 0x40(%esp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x0c'  # add $0xC, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_mark_comment_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x68\xd0\x07\x00\x00'  # push $0x7d0
+    handler_send_event_bytes += '\x8b\x85\x14\x04\x00\x00'  # mov 0x414(%ebp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x85\x10\x04\x00\x00'  # mov 0x410(%ebp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x14'  # add $0x14, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_delete_mark_comment_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x68\xd0\x07\x00\x00'  # push $0x7d0
+    handler_send_event_bytes += '\x8b\x46\x2c'  # mov 0x2c(%esi),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x46\x28'  # mov 0x28(%esi),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x14'  # add $0x14, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_add_hidden_area_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x0c'  # add $0xC, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_add_hidden_area_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x68\xd0\x07\x00\x00'  # push $0x7d0
+    handler_send_event_bytes += '\x51'  # push %ecx
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x14'  # add $0x14, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_enum_width_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x6a\x07'  # push $0x7
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x08'  # add $0x8, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+
+def build_enum_width_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x50'  # push %eax
+    handler_send_event_bytes += '\x57'  # push %edi
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x6a\x07'  # push $0x7
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x0C'  # add $0x14, %esp
+    handler_send_event_bytes += '\x58'
+
+    return handler_send_event_bytes
+

--- a/YaCo/patch/YaCoPatch_695.py
+++ b/YaCo/patch/YaCoPatch_695.py
@@ -1,0 +1,612 @@
+#   Copyright (C) 2017 YaKaPatcher
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import YaCoPatch
+
+#
+# IDA 695
+#
+# linux
+def ida_695_linux_32_hooks_offsets(libida_baseaddr):
+    hooks_offsets = {}
+
+    send_event_offset = 0x976e0
+    hooks_offsets['send_event_addr'] = libida_baseaddr + send_event_offset
+
+    regvar_hook_offset = 0x171782
+    hooks_offsets['regvar_hook_addr']= libida_baseaddr + regvar_hook_offset
+    hooks_offsets['regvar_hook_return_addr'] = hooks_offsets['regvar_hook_addr']+ 0x8
+
+    hooks_offsets['regvar_handler_bytes'] = build_regvar_handler_linux_32(hooks_offsets['send_event_addr'])
+
+    rename_regvar_hook_offset = 0x17111e
+    hooks_offsets['rename_hook_addr'] = libida_baseaddr + rename_regvar_hook_offset
+    hooks_offsets['rename_hook_return_addr'] = hooks_offsets['rename_hook_addr']+ 0x8
+
+    hooks_offsets['rename_handler_bytes'] = build_rename_regvar_handler_linux_32(hooks_offsets['send_event_addr'])
+
+    toggle_hook_offset = 0x8436a
+    hooks_offsets['toogle_hook_addr'] = libida_baseaddr + toggle_hook_offset
+    hooks_offsets['toogle_hook_return_addr'] = hooks_offsets['toogle_hook_addr'] + 0x8
+
+    hooks_offsets['toggle_sign_handler_bytes'] = build_toggle_sign_handler_linux_32(hooks_offsets['send_event_addr'])
+
+    mark_comment_hook_offset = 0x9bce4
+    hooks_offsets['mark_comment_hook_addr'] = libida_baseaddr + mark_comment_hook_offset
+    hooks_offsets['mark_comment_hook_return_addr'] = hooks_offsets['mark_comment_hook_addr'] + 0x9
+
+    hooks_offsets['mark_comment_handler_bytes'] = build_mark_comment_handler_linux_32(hooks_offsets['send_event_addr'])
+
+    add_hidden_area_hook_offset = 0x6d2f8
+    hooks_offsets['add_hidden_area_hook_addr'] = libida_baseaddr + add_hidden_area_hook_offset
+    hooks_offsets['add_hidden_area_hook_return_addr'] = hooks_offsets['add_hidden_area_hook_addr'] + 0x7
+
+    hooks_offsets['add_hidden_area_handler_bytes'] = build_add_hidden_area_handler_linux_32(hooks_offsets['send_event_addr'])
+
+    function_flags_hook_offset = 0x137f8b
+    hooks_offsets['function_flags_hook_addr'] = libida_baseaddr + function_flags_hook_offset
+    hooks_offsets['function_flags_hook_return_addr'] = hooks_offsets['function_flags_hook_addr'] + 0x9
+
+    hooks_offsets['function_flags_handler_bytes'] = build_function_flags_handler_linux_32(hooks_offsets['send_event_addr'])
+
+    enum_width_hook_offset = 0x8a415
+    hooks_offsets['enum_width_hook_addr'] = libida_baseaddr + enum_width_hook_offset
+    hooks_offsets['enum_width_hook_return_addr'] = hooks_offsets['enum_width_hook_addr'] + 0x8
+
+    hooks_offsets['enum_width_handler_bytes'] = build_enum_width_handler_linux_32(hooks_offsets['send_event_addr'])
+
+    return hooks_offsets
+
+def ida_695_linux_64_hooks_offsets(libida_baseaddr):
+    hooks_offsets = {}
+
+    send_event_offset = 0xac3d0
+    hooks_offsets['send_event_addr'] = libida_baseaddr + send_event_offset
+
+    regvar_hook_offset = 0x199248
+    hooks_offsets['regvar_hook_addr']= libida_baseaddr + regvar_hook_offset
+    hooks_offsets['regvar_hook_return_addr'] = hooks_offsets['regvar_hook_addr']+ 0x7
+
+    hooks_offsets['regvar_handler_bytes'] = build_regvar_handler_linux_64(hooks_offsets['send_event_addr'])
+
+    rename_regvar_hook_offset = 0x198a19
+    hooks_offsets['rename_hook_addr'] = libida_baseaddr + rename_regvar_hook_offset
+    hooks_offsets['rename_hook_return_addr'] = hooks_offsets['rename_hook_addr']+ 0x8
+
+    hooks_offsets['rename_handler_bytes'] = build_rename_regvar_handler_linux_64(hooks_offsets['send_event_addr'])
+
+    toggle_hook_offset = 0x92ea2
+    hooks_offsets['toogle_hook_addr'] = libida_baseaddr + toggle_hook_offset
+    hooks_offsets['toogle_hook_return_addr'] = hooks_offsets['toogle_hook_addr'] + 0xC
+
+    hooks_offsets['toggle_sign_handler_bytes'] = build_toggle_sign_handler_linux_64(hooks_offsets['send_event_addr'])
+
+    mark_comment_hook_offset = 0xb11d1
+    hooks_offsets['mark_comment_hook_addr'] = libida_baseaddr + mark_comment_hook_offset
+    hooks_offsets['mark_comment_hook_return_addr'] = hooks_offsets['mark_comment_hook_addr'] + 0x8
+
+    hooks_offsets['mark_comment_handler_bytes'] = build_mark_comment_handler_linux_64(hooks_offsets['send_event_addr'])
+
+    add_hidden_area_hook_offset = 0x75412
+    hooks_offsets['add_hidden_area_hook_addr'] = libida_baseaddr + add_hidden_area_hook_offset
+    hooks_offsets['add_hidden_area_hook_return_addr'] = hooks_offsets['add_hidden_area_hook_addr'] + 0x8
+
+    hooks_offsets['add_hidden_area_handler_bytes'] = build_add_hidden_area_handler_linux_64(hooks_offsets['send_event_addr'])
+
+    function_flags_hook_offset = 0x158ad4
+    hooks_offsets['function_flags_hook_addr'] = libida_baseaddr + function_flags_hook_offset
+    hooks_offsets['function_flags_hook_return_addr'] = hooks_offsets['function_flags_hook_addr'] + 0x7
+
+    hooks_offsets['function_flags_handler_bytes'] = build_function_flags_handler_linux_64(hooks_offsets['send_event_addr'])
+
+    enum_width_hook_offset = 0x9b4b1
+    hooks_offsets['enum_width_hook_addr'] = libida_baseaddr + enum_width_hook_offset
+    hooks_offsets['enum_width_hook_return_addr'] = hooks_offsets['enum_width_hook_addr'] + 0x8
+
+    hooks_offsets['enum_width_handler_bytes'] = build_enum_width_handler_linux_64(hooks_offsets['send_event_addr'])
+
+    return hooks_offsets
+
+# windows
+def ida_695_windows_32_hooks_offsets(libida_baseaddr):
+    hooks_offsets = {}
+
+    send_event_offset = 0x146690
+    hooks_offsets['send_event_addr'] = libida_baseaddr + send_event_offset
+
+    regvar_hook_offset = 0x927c8
+    hooks_offsets['regvar_hook_addr']= libida_baseaddr + regvar_hook_offset
+    hooks_offsets['regvar_hook_return_addr'] = hooks_offsets['regvar_hook_addr']+ 0x8
+
+    hooks_offsets['regvar_handler_bytes'] = build_regvar_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    rename_regvar_hook_offset = 0x92b19
+    hooks_offsets['rename_hook_addr'] = libida_baseaddr + rename_regvar_hook_offset
+    hooks_offsets['rename_hook_return_addr'] = hooks_offsets['rename_hook_addr']+ 0x6
+
+    hooks_offsets['rename_handler_bytes'] = build_rename_regvar_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    toggle_hook_offset = 0x569d0
+    hooks_offsets['toogle_hook_addr'] = libida_baseaddr + toggle_hook_offset
+    hooks_offsets['toogle_hook_return_addr'] = hooks_offsets['toogle_hook_addr'] + 0x6
+
+    hooks_offsets['toggle_sign_handler_bytes'] = build_toggle_sign_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    mark_comment_hook_offset = 0xff65a
+    hooks_offsets['mark_comment_hook_addr'] = libida_baseaddr + mark_comment_hook_offset
+    hooks_offsets['mark_comment_hook_return_addr'] = hooks_offsets['mark_comment_hook_addr'] + 0x6
+
+    hooks_offsets['mark_comment_handler_bytes'] = build_mark_comment_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    add_hidden_area_hook_offset = 0xec8b2
+    hooks_offsets['add_hidden_area_hook_addr'] = libida_baseaddr + add_hidden_area_hook_offset
+    hooks_offsets['add_hidden_area_hook_return_addr'] = hooks_offsets['add_hidden_area_hook_addr'] + 0x6
+
+    hooks_offsets['add_hidden_area_handler_bytes'] = build_add_hidden_area_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    function_flags_hook_offset = 0x785d6
+    hooks_offsets['function_flags_hook_addr'] = libida_baseaddr + function_flags_hook_offset
+    hooks_offsets['function_flags_hook_return_addr'] = hooks_offsets['function_flags_hook_addr'] + 0x7
+
+    hooks_offsets['function_flags_handler_bytes'] = build_function_flags_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    enum_width_hook_offset = 0x7f58a
+    hooks_offsets['enum_width_hook_addr'] = libida_baseaddr + enum_width_hook_offset
+    hooks_offsets['enum_width_hook_return_addr'] = hooks_offsets['enum_width_hook_addr'] + 0x6
+
+    hooks_offsets['enum_width_handler_bytes'] = build_enum_width_handler_windows_32(hooks_offsets['send_event_addr'])
+
+    return hooks_offsets
+
+def ida_695_windows_64_hooks_offsets(libida_baseaddr):
+    hooks_offsets = {}
+
+    send_event_offset = 0x15d830
+    hooks_offsets['send_event_addr'] = libida_baseaddr + send_event_offset
+
+    regvar_hook_offset = 0x9f58a
+    hooks_offsets['regvar_hook_addr']= libida_baseaddr + regvar_hook_offset
+    hooks_offsets['regvar_hook_return_addr'] = hooks_offsets['regvar_hook_addr']+ 0x6
+
+    hooks_offsets['regvar_handler_bytes'] = build_regvar_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    rename_regvar_hook_offset = 0x9fc09
+    hooks_offsets['rename_hook_addr'] = libida_baseaddr + rename_regvar_hook_offset
+    hooks_offsets['rename_hook_return_addr'] = hooks_offsets['rename_hook_addr']+ 0x6
+
+    hooks_offsets['rename_handler_bytes'] = build_rename_regvar_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    toggle_hook_offset = 0x5d975
+    hooks_offsets['toogle_hook_addr'] = libida_baseaddr + toggle_hook_offset
+    hooks_offsets['toogle_hook_return_addr'] = hooks_offsets['toogle_hook_addr'] + 0xA
+
+    hooks_offsets['toggle_sign_handler_bytes'] = build_toggle_sign_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    mark_comment_hook_offset = 0x114b43
+    hooks_offsets['mark_comment_hook_addr'] = libida_baseaddr + mark_comment_hook_offset
+    hooks_offsets['mark_comment_hook_return_addr'] = hooks_offsets['mark_comment_hook_addr'] + 0x6
+
+    hooks_offsets['mark_comment_handler_bytes'] = build_mark_comment_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    add_hidden_area_hook_offset = 0x100fa5
+    hooks_offsets['add_hidden_area_hook_addr'] = libida_baseaddr + add_hidden_area_hook_offset
+    hooks_offsets['add_hidden_area_hook_return_addr'] = hooks_offsets['add_hidden_area_hook_addr'] + 0x6
+
+    hooks_offsets['add_hidden_area_handler_bytes'] = build_add_hidden_area_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    function_flags_hook_offset = 0x81a56
+    hooks_offsets['function_flags_hook_addr'] = libida_baseaddr + function_flags_hook_offset
+    hooks_offsets['function_flags_hook_return_addr'] = hooks_offsets['function_flags_hook_addr'] + 0x6
+
+    hooks_offsets['function_flags_handler_bytes'] = build_function_flags_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    enum_width_hook_offset = 0x8afea
+    hooks_offsets['enum_width_hook_addr'] = libida_baseaddr + enum_width_hook_offset
+    hooks_offsets['enum_width_hook_return_addr'] = hooks_offsets['enum_width_hook_addr'] + 0x6
+
+    hooks_offsets['enum_width_handler_bytes'] = build_enum_width_handler_windows_64(hooks_offsets['send_event_addr'])
+
+    return hooks_offsets
+
+#
+# REGVAR
+#
+def build_regvar_handler_windows_32(send_event_addr):
+
+    return build_regvar_handler_linux_32(send_event_addr)
+
+def build_regvar_handler_linux_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_regvar_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x60' # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x53'  # push %ebx
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_regvar_handler_linux_64(send_event_addr):
+    handler_send_event_bytes = '\x60' # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x45\x04'  # mov 0x04(%ebp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x45\x00'  # mov 0x00(%ebp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+#
+# RENAME REGVAR
+#
+def build_rename_regvar_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_rename_regvar_handler_linux_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x07'  # mov    (%edi),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_rename_regvar_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x60' # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x43\x04'  # mov 0x4(%ebx),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x03'  # mov (%ebx),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_rename_regvar_handler_linux_64(send_event_addr):
+    handler_send_event_bytes = '\x60' # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x47\x04'  # mov 0x04(%edi),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x07'  # mov 0x00(%edi),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+#
+# TOGGLE SIGN
+#
+def build_toggle_sign_handler_windows_32(send_event_addr):
+
+    return build_toggle_sign_handler_linux_32(send_event_addr)
+
+def build_toggle_sign_handler_linux_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_toggle_sign_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x60' # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x57'  # push %edi
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_toggle_sign_handler_linux_64(send_event_addr):
+    handler_send_event_bytes = '\x60' # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x55'  # push %ebp
+    handler_send_event_bytes += '\x57'  # push %edi
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+#
+# BOOKMARK
+#
+def build_mark_comment_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x85\xf8\x00\x00\x00'  # mov 0xf8(%ebp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_mark_comment_handler_linux_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_mark_comment_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x85\xf4\x00\x00\x00'  # mov 0xf4(%ebp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x85\xf8\x00\x00\x00'  # mov 0xf8(%ebp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_mark_comment_handler_linux_64(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x57'  # push %edi
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+#
+# HIDDEN AREA
+#
+def build_add_hidden_area_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x06'  # mov (%esi), %eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_add_hidden_area_handler_linux_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x55'  # push %ebp
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_add_hidden_area_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x46\x04'  # mov 0x4(%esi), %eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x06'  # mov (%esi), %eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_add_hidden_area_handler_linux_64(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x47\x04'  # mov 0x04(%edi),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x07'  # mov 0x00(%edi),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+#
+# FUNCTION FLAGS
+#
+def build_function_flags_handler_windows_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x07'  # mov 0x00(%edi),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_function_flags_handler_linux_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x00'  # mov (%ebx), %eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_function_flags_handler_windows_64(send_event_addr):
+    return build_function_flags_handler_linux_64(send_event_addr)
+
+def build_function_flags_handler_linux_64(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x8b\x45\x04'  # mov 0x04(%ebp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x8b\x45\x00'  # mov 0x00(%ebp),%eax
+    handler_send_event_bytes += '\x50'  # push %eax
+    handler_send_event_bytes += '\x6a\x01'  # push $0x1
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+#
+# ENUM WIDTH
+#
+def build_enum_width_handler_windows_32(send_event_addr):
+    return build_enum_width_handler_linux_32(send_event_addr)
+
+def build_enum_width_handler_linux_32(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x6a\x07'  # push $0x7
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_enum_width_handler_windows_64(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x57'  # push %edi
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x6a\x07'  # push $0x7
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+
+def build_enum_width_handler_linux_64(send_event_addr):
+    handler_send_event_bytes = '\x60'  # pusha
+    handler_send_event_bytes += '\x6a\x00'  # push $0x0
+    handler_send_event_bytes += '\x56'  # push %esi
+    handler_send_event_bytes += '\x57'  # push %edi
+    handler_send_event_bytes += '\x6a\x07'  # push $0x7
+    handler_send_event_bytes += '\xb8'
+    handler_send_event_bytes += YaCoPatch.pack_address(send_event_addr)  # mov send_event_addr, %eax
+    handler_send_event_bytes += '\xff\xd0'  # call %eax
+    handler_send_event_bytes += '\x83\xc4\x10'  # add $0x10, %esp
+    handler_send_event_bytes += '\x61' # popa
+
+    return handler_send_event_bytes
+

--- a/YaCo/patch/__init__.py
+++ b/YaCo/patch/__init__.py
@@ -1,0 +1,15 @@
+#   Copyright (C) 2017 YaKaPatcher
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+

--- a/tests/yaunit/test_comments.py
+++ b/tests/yaunit/test_comments.py
@@ -18,7 +18,6 @@ import idc
 import unittest
 import yaunit
 import idautils
-import sys
 
 import logging
 logger = logging.getLogger("YaCo")
@@ -93,7 +92,6 @@ class Fixture(unittest.TestCase):
                         try_ext_lin(idc.ExtLinA, ea, i, txt)
         yaunit.save('comments', eas)
 
-    @unittest.skipIf(sys.platform == "linux2", "unsupported")
     def yacheck_comments(self):
         eas = yaunit.load('comments')
         i = 0
@@ -174,7 +172,6 @@ class Fixture(unittest.TestCase):
                         try_ext_lin(idc.ExtLinA, ea, i, txt)
         yaunit.save('data_comments', eas)
 
-    @unittest.skipIf(sys.platform == "linux2", "unsupported")
     def yacheck_data_comments(self):
         eas = yaunit.load('data_comments')
         i = 0

--- a/tests/yaunit/test_hiddenarea.py
+++ b/tests/yaunit/test_hiddenarea.py
@@ -40,7 +40,6 @@ class Fixture(unittest.TestCase):
             self.assertTrue(False)
         self.assertEqual(hidden_area.description, bookmark)
 
-    @unittest.skip("not implemented")
     def yacheck_hiddenareas(self):
         addrs = yaunit.load('hiddenarea')
         for i in range(0, 3):

--- a/tests/yaunit/test_registers.py
+++ b/tests/yaunit/test_registers.py
@@ -45,7 +45,6 @@ class Fixture(unittest.TestCase):
                     self.assertEqual(idaapi.add_regvar(func, ea, end, text, key, None), idaapi.REGVAR_ERROR_OK)
         yaunit.save('registers', eas)
 
-    @unittest.skip("not implemented")
     def yacheck_rename_register(self):
         eas = yaunit.load('registers')
         for ea, op, key in eas:


### PR DESCRIPTION
 regvars, hidden areas, pre/post comments, bookmarks, operands sign, enums properties, functions properties

Supported IDA versions:
 - IDA 6.8 Windows
 - IDA 6.95 Windows
 - IDA 6.95 Linux