### PR TITLE
Adding the option to choose IDB tracking

### DIFF
--- a/YaLibs/YaGitLib/YaGitLib.cpp
+++ b/YaLibs/YaGitLib/YaGitLib.cpp
@@ -539,7 +539,7 @@ bool GitRepo::is_tracked(const std::string& path)
 {
     unsigned int flags = 0;
     const auto err = git_status_file(&flags, repository, path.data());
-    return err == GIT_OK && !(flags & GIT_STATUS_WT_NEW);
+    return err == GIT_OK && !(flags & (GIT_STATUS_WT_NEW | GIT_STATUS_IGNORED));
 }
 
 std::set<std::string> GitRepo::get_conflicted_objects()

--- a/YaLibs/YaGitLib/YaGitLib.cpp
+++ b/YaLibs/YaGitLib/YaGitLib.cpp
@@ -535,6 +535,13 @@ std::set<std::string> GitRepo::get_untracked_objects()
     return objects;
 }
 
+bool GitRepo::is_tracked(const std::string& path)
+{
+    unsigned int flags = 0;
+    const auto err = git_status_file(&flags, repository, path.data());
+    return err == GIT_OK && !(flags & GIT_STATUS_WT_NEW);
+}
+
 std::set<std::string> GitRepo::get_conflicted_objects()
 {
     std::set<std::string>   objects;

--- a/YaLibs/YaGitLib/YaGitLib.hpp
+++ b/YaLibs/YaGitLib/YaGitLib.hpp
@@ -97,6 +97,8 @@ public:
     std::set<std::tuple<std::string, bool, bool, bool>> get_status_in_path(const std::string& path);
 #endif //SWIGPYTHON
 
+    bool is_tracked(const std::string& path);
+
     std::string get_commit(const std::string& name);
     void push(const std::string& src_ref, const std::string& dst_ref);
 

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -13,6 +13,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#define USE_STANDARD_FILE_FUNCTIONS
 #include "Ida.h"
 #include "Repository.hpp"
 

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -299,14 +299,14 @@ Repository::Repository(const std::string& path)
     if (repo_already_exists)
     {
         include_idb_ = is_file_tracked(get_original_idb_path());
-        LOG(INFO, "The IDB is%s tracked\n", this->include_idb_ ? "" : " not");
+        LOG(INFO, "The IDB is%s tracked\n", include_idb_ ? "" : " not");
         LOG(DEBUG, "Repo opened\n");
         return;
     }
     LOG(INFO, "Repo created\n");
 
     include_idb_ = ask_for_idb_tracking();
-    LOG(INFO, "The IDB is%s tracked\n", this->include_idb_ ? "" : " not");
+    LOG(INFO, "The IDB is%s tracked\n", include_idb_ ? "" : " not");
 
     // add current IDB to repo, and create an initial commit
     if (add_file_to_index(get_current_idb_name()) && commit("Initial commit\n"))
@@ -774,10 +774,9 @@ bool Repository::add_file_to_index(const std::string& path)
         (path == get_current_idb_name() ||
         path == get_original_idb_name()))
     {
-        p.replace_extension(".idx_file");
-        std::fstream f;
+        p = ".gitignore";
         f.open(p, std::fstream::out);
-        f << "DO NOT DELETE!" << std::endl;
+        f << get_current_idb_path() << std::endl;
     }
     try
     {

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -281,7 +281,8 @@ namespace
 
         GitRepo repo_;
         std::vector<std::string> comments_;
-        bool repo_auto_sync_, include_idb_;
+        bool repo_auto_sync_;
+        bool include_idb_;
     };
 }
 
@@ -297,7 +298,7 @@ Repository::Repository(const std::string& path)
 
     if (repo_already_exists)
     {
-        this->include_idb_ = is_file_tracked(get_original_idb_path());
+        include_idb_ = is_file_tracked(get_original_idb_path());
         LOG(INFO, "The IDB is%s tracked\n", this->include_idb_ ? "" : " not");
         LOG(DEBUG, "Repo opened\n");
         return;
@@ -620,7 +621,7 @@ void Repository::ask_to_checkout_modified_files()
 
 bool Repository::ask_for_idb_tracking()
 {
-     return (ask_yn(true, "Should the IDB be tracked?") == ASKBTN_YES);
+     return ask_yn(true, "Should the IDB be tracked?") == ASKBTN_YES;
 }
 
 void Repository::ask_for_remote()
@@ -703,8 +704,7 @@ bool Repository::ask_and_set_git_config_entry(const std::string& config_entry, c
 
 bool Repository::is_file_tracked(const std::string& path)
 {
-    bool is_tracked = !repo_.get_untracked_objects_in_path(path).empty();
-    return is_tracked;
+    return !repo_.get_untracked_objects_in_path(path).empty();
 }
 
 bool Repository::ensure_git_globals()
@@ -772,7 +772,8 @@ bool Repository::add_file_to_index(const std::string& path)
     fs::path p = path;
     if (!include_idb_ &&
         (path == get_current_idb_name() ||
-        path == get_original_idb_name())) {
+        path == get_original_idb_name()))
+    {
         p.replace_extension(".idx_file");
         std::fstream f;
         f.open(p, std::fstream::out);

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -290,6 +290,7 @@ namespace
 Repository::Repository(const std::string& path)
     : repo_(path)
     , repo_auto_sync_(true)
+    , include_idb_(false)
 {
     const bool repo_already_exists = is_git_working_dir(path);
 

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -298,14 +298,14 @@ Repository::Repository(const std::string& path)
     if (repo_already_exists)
     {
         this->include_idb_ = is_file_tracked(get_original_idb_path());
-        LOG(INFO, "1 The IDB is%s tracked\n", this->include_idb_ ? "" : " not");
+        LOG(INFO, "The IDB is%s tracked\n", this->include_idb_ ? "" : " not");
         LOG(DEBUG, "Repo opened\n");
         return;
     }
     LOG(INFO, "Repo created\n");
 
     include_idb_ = ask_for_idb_tracking();
-    LOG(INFO, "2 The IDB is%s tracked\n", this->include_idb_ ? "" : " not");
+    LOG(INFO, "The IDB is%s tracked\n", this->include_idb_ ? "" : " not");
 
     // add current IDB to repo, and create an initial commit
     if (add_file_to_index(get_current_idb_name()) && commit("Initial commit\n"))

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -776,6 +776,7 @@ bool Repository::add_file_to_index(const std::string& path)
         path == get_original_idb_name()))
     {
         p = ".gitignore";
+        std::fstream f;
         f.open(p, std::fstream::out);
         f << get_current_idb_path() << std::endl;
     }
@@ -793,11 +794,6 @@ bool Repository::add_file_to_index(const std::string& path)
 
 bool Repository::remove_file_for_index(const std::string& path)
 {
-    if (!include_idb_ &&
-        (path == get_current_idb_name() ||
-        path == get_original_idb_name())) {
-        return true;
-    }
     try
     {
         repo_.remove_file(path);

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -279,7 +279,6 @@ namespace
         bool push(const std::string& src_branch, const std::string& dst_branch);
         bool remote_exist(const std::string& remote);
         std::string get_commit(const std::string& ref);
-        bool is_file_tracked(const std::string& path);
 
         GitRepo repo_;
         std::vector<std::string> comments_;
@@ -300,7 +299,7 @@ Repository::Repository(const std::string& path)
 
     if (repo_already_exists)
     {
-        include_idb_ = is_file_tracked(get_original_idb_path());
+        include_idb_ = repo_.is_tracked(get_original_idb_name());
         LOG(INFO, "The IDB is%s tracked\n", include_idb_ ? "" : " not");
         LOG(DEBUG, "Repo opened\n");
         return;
@@ -702,11 +701,6 @@ bool Repository::ask_and_set_git_config_entry(const std::string& config_entry, c
         return false;
     }
     return true;
-}
-
-bool Repository::is_file_tracked(const std::string& path)
-{
-    return !repo_.get_untracked_objects_in_path(path).empty();
 }
 
 bool Repository::ensure_git_globals()

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -781,11 +781,11 @@ bool Repository::add_file_to_index(const std::string& path)
     }
     try
     {
-        repo_.add_file(p);
+        repo_.add_file(p.generic_string());
     }
     catch (const std::runtime_error& error)
     {
-        LOG(WARNING, "Failed to add %s to index, error: %s\n", p.c_str(), error.what());
+        LOG(WARNING, "Failed to add %s to index, error: %s\n", p.generic_string().c_str(), error.what());
         return false;
     }
     return true;

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -259,6 +259,7 @@ namespace
         void sync_and_push_original_idb() override;
         void discard_and_pull_idb() override;
         void diff_index(const std::string& from, const on_blob_fn& on_blob) const override;
+        bool idb_is_tracked();
 
         // Retrieve informations with IDA GUI
         void ask_to_checkout_modified_files();
@@ -879,6 +880,10 @@ void Repository::diff_index(const std::string& from, const on_blob_fn& on_blob) 
     {
         LOG(WARNING, "unable to diff index: %s\n", error.what());
     }
+}
+
+bool Repository::idb_is_tracked() {
+    return include_idb_;
 }
 
 std::shared_ptr<IRepository> MakeRepository(const std::string& path)

--- a/YaLibs/YaToolsIDALib/Repository.cpp
+++ b/YaLibs/YaToolsIDALib/Repository.cpp
@@ -877,7 +877,8 @@ void Repository::diff_index(const std::string& from, const on_blob_fn& on_blob) 
     }
 }
 
-bool Repository::idb_is_tracked() {
+bool Repository::idb_is_tracked()
+{
     return include_idb_;
 }
 

--- a/YaLibs/YaToolsIDALib/Repository.hpp
+++ b/YaLibs/YaToolsIDALib/Repository.hpp
@@ -42,6 +42,8 @@ struct IRepository
 
     typedef std::function<int(const char*, bool, const void*, size_t)> on_blob_fn;
     virtual void diff_index(const std::string& from, const on_blob_fn& on_blob) const = 0;
+
+    virtual bool idb_is_tracked() = 0;
 };
 
 std::shared_ptr<IRepository> MakeRepository(const std::string& path);

--- a/YaLibs/YaToolsIDALib/YaCo.cpp
+++ b/YaLibs/YaToolsIDALib/YaCo.cpp
@@ -129,7 +129,8 @@ YaCo::YaCo()
 
     #define YACO_ACTION_DESC(name, label, handler) ACTION_DESC_LITERAL_OWNER(name, label, handler, nullptr, nullptr, nullptr, -1)
     action_descs_.push_back(YACO_ACTION_DESC("yaco_toggle_rebase_push",     "YaCo - Toggle YaCo auto rebase/push",   new_handler([&]{ toggle_auto_rebase_push(); })));
-    if(repo_->idb_is_tracked()) {
+    if(repo_->idb_is_tracked())
+    {
         action_descs_.push_back(YACO_ACTION_DESC("yaco_sync_and_push_idb", "YaCo - Resync idb & force push", new_handler([&] { sync_and_push_idb(IDA_INTERACTIVE); })));
         action_descs_.push_back(YACO_ACTION_DESC("yaco_discard_and_pull_idb", "YaCo - Discard idb & force pull", new_handler([&] { discard_and_pull_idb(IDA_INTERACTIVE); })));
     }

--- a/YaLibs/YaToolsIDALib/YaCo.cpp
+++ b/YaLibs/YaToolsIDALib/YaCo.cpp
@@ -129,8 +129,10 @@ YaCo::YaCo()
 
     #define YACO_ACTION_DESC(name, label, handler) ACTION_DESC_LITERAL_OWNER(name, label, handler, nullptr, nullptr, nullptr, -1)
     action_descs_.push_back(YACO_ACTION_DESC("yaco_toggle_rebase_push",     "YaCo - Toggle YaCo auto rebase/push",   new_handler([&]{ toggle_auto_rebase_push(); })));
-    action_descs_.push_back(YACO_ACTION_DESC("yaco_sync_and_push_idb",      "YaCo - Resync idb & force push",        new_handler([&]{ sync_and_push_idb(IDA_INTERACTIVE); })));
-    action_descs_.push_back(YACO_ACTION_DESC("yaco_discard_and_pull_idb",   "YaCo - Discard idb & force pull",       new_handler([&]{ discard_and_pull_idb(IDA_INTERACTIVE); })));
+    if(repo_->idb_is_tracked()) {
+        action_descs_.push_back(YACO_ACTION_DESC("yaco_sync_and_push_idb", "YaCo - Resync idb & force push", new_handler([&] { sync_and_push_idb(IDA_INTERACTIVE); })));
+        action_descs_.push_back(YACO_ACTION_DESC("yaco_discard_and_pull_idb", "YaCo - Discard idb & force pull", new_handler([&] { discard_and_pull_idb(IDA_INTERACTIVE); })));
+    }
     action_descs_.push_back(YACO_ACTION_DESC("yaco_export_database",        "YaCo - Export database",                new_handler([&]{ export_database(); })));
     #undef YACO_ACTION_DESC
 

--- a/YaLibs/YaToolsPy/YaSwig.cpp
+++ b/YaLibs/YaToolsPy/YaSwig.cpp
@@ -22,6 +22,8 @@
 #include <IdaVisitor.hpp>
 #include <YaHelpers.hpp>
 
+#include <fstream>
+
 namespace yaswig
 {
     Private make_yaco()

--- a/YaLibs/YaToolsPy/YaSwig.cpp
+++ b/YaLibs/YaToolsPy/YaSwig.cpp
@@ -22,8 +22,6 @@
 #include <IdaVisitor.hpp>
 #include <YaHelpers.hpp>
 
-#include <fstream>
-
 namespace yaswig
 {
     Private make_yaco()


### PR DESCRIPTION
IDBs can be very large, and so are often difficult to maintain in a cloud based repository like GitHub.  This pull requests adds the ability for the user to opt out of including the IDB file for versioning.